### PR TITLE
Fix Bluetooth device discovery

### DIFF
--- a/app/src/main/java/com/example/vs_app/BluetoothController.java
+++ b/app/src/main/java/com/example/vs_app/BluetoothController.java
@@ -34,15 +34,48 @@ public class BluetoothController {
         void onBluetoothNotAvailable();
     }
 
-    public BluetoothController(Context context, BluetoothCallback callback) {
+    public BluetoothController(Context context) {
         this.context = context;
         this.bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         this.mainHandler = new Handler(Looper.getMainLooper());
         this.groupManager = GroupManager.getInstance();
         this.isRunning = new AtomicBoolean(false);
-        this.bluetoothCallback = callback;
 
         if (bluetoothAdapter == null) {
+            Log.e(TAG, "Bluetooth is not available on this device");
+        }
+    }
+
+    public BluetoothController(Context context, BluetoothCallback callback) {
+        this(context);
+        this.bluetoothCallback = callback;
+
+        if (bluetoothAdapter == null && bluetoothCallback != null) {
             mainHandler.post(() -> bluetoothCallback.onBluetoothNotAvailable());
         }
     }
+
+    public BluetoothAdapter getBluetoothAdapter() {
+        return bluetoothAdapter;
+    }
+
+    @SuppressLint("MissingPermission")
+    public void startDiscovery() {
+        if (bluetoothAdapter != null) {
+            Log.d(TAG, "Starting Bluetooth discovery");
+            if (bluetoothAdapter.isDiscovering()) {
+                bluetoothAdapter.cancelDiscovery();
+            }
+            bluetoothAdapter.startDiscovery();
+        } else {
+            Log.e(TAG, "Cannot start discovery - Bluetooth adapter is null");
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    public void stopDiscovery() {
+        if (bluetoothAdapter != null && bluetoothAdapter.isDiscovering()) {
+            bluetoothAdapter.cancelDiscovery();
+        }
+    }
+}


### PR DESCRIPTION
Dieser Pull Request behebt mehrere Probleme mit der Bluetooth-Gerätesuche:

1. BluetoothController wurde überarbeitet:
   - Zusätzlicher Constructor für die Verwendung ohne Callback
   - Implementierung von startDiscovery() und stopDiscovery()
   - Verbesserte Fehlerbehandlung und Logging

2. DiscoveryView wurde verbessert:
   - Zusätzliche BroadcastReceiver Actions für Discovery Start/Ende
   - Besseres Status-Feedback in der UI
   - Verbessertes Logging für Debugging
   - Korrektur der Device-Liste Aktualisierung

3. Status-Updates:
   - Klare Statusmeldungen für verschiedene Zustände
   - Bessere Fehlerbehandlung bei fehlenden Berechtigungen
   - Feedback wenn Bluetooth nicht aktiviert ist

Die Änderungen sollten dazu führen, dass:
- Geräte korrekt gefunden und angezeigt werden
- Der Benutzer besseres Feedback über den Status der Suche erhält
- Fehler besser nachvollzogen werden können durch zusätzliches Logging